### PR TITLE
release 8.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@basemachina/react-inspector",
-  "version": "8.1.0",
+  "version": "8.1.1",
   "description": "Power of Browser DevTools inspectors right inside your React app",
   "keywords": [
     "devtools",


### PR DESCRIPTION
8.1.0 doesn't include build output, which is my fault, so I released patch version https://www.npmjs.com/package/@basemachina/react-inspector/v/8.1.1
